### PR TITLE
Fixed a crash when bottomsheet would render on non-UI thread

### DIFF
--- a/android/src/main/java/com/gnet/bottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/gnet/bottomsheet/RNBottomSheet.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 
 import org.json.JSONObject;
 
@@ -40,7 +41,7 @@ class RNBottomSheet extends ReactContextBaseJavaModule {
         ReadableArray optionArray = options.getArray("options");
         final Integer cancelButtonIndex = options.getInt("cancelButtonIndex");
 
-        BottomSheet.Builder builder = new BottomSheet.Builder(this.getCurrentActivity());
+        final BottomSheet.Builder builder = new BottomSheet.Builder(this.getCurrentActivity());
 
         // create options
         Integer size = optionArray.size();
@@ -59,7 +60,12 @@ class RNBottomSheet extends ReactContextBaseJavaModule {
             }
         });
 
-        builder.build().show();
+        UiThreadUtil.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                builder.build().show();
+            }
+        });
     }
 
     @ReactMethod


### PR DESCRIPTION
This PR fixes a crash when bottom sheet builder would render on a non-UI thread. Unless specified builder show could render on any thread according to react native documentation.

With the following code change, crashes we were seeing due to bottomsheet rendering have been fixed.