### PR TITLE
Fix RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/gnet/bottomsheet/RNBottomSheetPackage.java
+++ b/android/src/main/java/com/gnet/bottomsheet/RNBottomSheetPackage.java
@@ -27,7 +27,7 @@ public class RNBottomSheetPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Remove Override to fix RN 0.47 breaking change. Remains backwards compatible